### PR TITLE
async bloc + test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 0.2.0
+
+- ***Breaking Change***
+    use contructor for unique selector
+        SelectorBloc(); // not unique
+        SelectorBloc.unique();
+
+- `AsyncTaskBloc` and `AsyncCachedTaskBloc`
+
+- ***Deprecated***
+    + `requestSink` renamed to `callSink`
+    + `onLoading` renamed to `onRunning`
+    + `onRequest` renamed to `onResult`
+    + `onRequest` renamed to `onStart`
+    + `cachedResponse` renamed to `cachedResult`
+    + `updateCachedResponseSink` to `updateCachedResultSink`
+
 ## 0.1.1
 
 - fix selector

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
     + `requestSink` renamed to `callSink`
     + `onLoading` renamed to `onRunning`
     + `onRequest` renamed to `onResult`
-    + `onRequest` renamed to `onStart`
+    + `onRequest` renamed to `onCall`
     + `cachedResponse` renamed to `cachedResult`
     + `updateCachedResponseSink` to `updateCachedResultSink`
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 This package contain helper class and common Bloc Pattern
 
 - Bloc (base to implement Bloc pattern)
+- AsyncTaskBloc
+- AsyncCachedTaskBloc
 - RequestBloc
 - CachedRequestBloc
 - SelectorBloc
@@ -36,21 +38,21 @@ abstract class Bloc {
 
 RequestBloc help to implement async call, it provides following stream ans sink.
 
-`Sink<Request> requestSink`
+`Sink<Request> callSink`
 
-`Stream<bool> onLoading`
+`Stream<bool> onRunning`
 
-`Stream<Request> onRequest`
+`Stream<Request> onCall`
 
-`Stream<Response> onResponse`
+`Stream<Response> onResult`
 
 CachedRequestBloc add the ability to cache response, to avoid multiple call when request does not change, it provides following stream and sink.
 
-`Stream<Response> cachedResponse`
+`Stream<Response> cachedResult`
 
 `Sink<Response> invalidateCacheSink`
 
-`Sink<Response> updateCachedResponseSink`
+`Sink<Response> updateCachedResultSink`
 
 #### Usage
 
@@ -67,7 +69,7 @@ class MyRequestBloc extends RequestBloc<MyRequest, MyResponse> {
   }
 }
 
-bloc.requestSink.add(MyRequest());
+bloc.callSink.add(MyRequest());
 ```
 
 See [example](https://github.com/lejard-h/bloc_helpers/tree/master/example/request.dart)

--- a/example/request.dart
+++ b/example/request.dart
@@ -19,12 +19,12 @@ class MyRequest {}
 main() {
   final bloc = MyRequestBloc();
 
-  bloc.onLoading.listen((loading) => print('loading $loading'));
+  bloc.onRunning.listen((loading) => print('loading $loading'));
 
-  bloc.onResponse.listen(
+  bloc.onResult.listen(
     (response) => print(response),
     onError: (error) => print(error),
   );
 
-  bloc.requestSink.add(MyRequest());
+  bloc.callSink.add(MyRequest());
 }

--- a/lib/bloc_helpers.dart
+++ b/lib/bloc_helpers.dart
@@ -1,5 +1,5 @@
 library bloc_helpers;
 
 export 'src/bloc.dart';
-export 'src/request.dart';
+export 'src/async.dart';
 export 'src/selector.dart';

--- a/lib/src/async.dart
+++ b/lib/src/async.dart
@@ -20,7 +20,7 @@ abstract class AsyncTaskBloc<Parameter, Result> extends Bloc {
   final _runningBehavior = new BehaviorSubject<bool>(seedValue: false);
 
   AsyncTaskBloc() {
-    onStart.listen(_handleTask);
+    onCall.listen(_handleTask);
   }
 
   Future<void> _handleTask(Parameter input) async {
@@ -52,7 +52,7 @@ abstract class AsyncTaskBloc<Parameter, Result> extends Bloc {
   ValueObservable<bool> get onRunning => _runningBehavior.stream;
 
   /// Task will start stream
-  Observable<Parameter> get onStart => _callPublisher.stream;
+  Observable<Parameter> get onCall => _callPublisher.stream;
 
   /// Result stream
   Observable<Result> get onResult => _resultPublisher.stream;
@@ -111,7 +111,7 @@ abstract class AsyncCachedTaskBloc<Parameter, Result>
       : _cachedResultBehavior =
             new BehaviorSubject<Result>(seedValue: seedValue),
         super() {
-    onResult.listen(_onResponse, onError: _onError);
+    onResult.listen(_onResult, onError: _onError);
     _invalidatePublisher.stream.listen((value) {
       _cached = false;
       _cachedParameterBehavior.add(null);
@@ -136,7 +136,7 @@ abstract class AsyncCachedTaskBloc<Parameter, Result>
     _cachedResultBehavior.addError(e, s);
   }
 
-  void _onResponse(Result response) {
+  void _onResult(Result response) {
     _cached = true;
     if (disposed) return;
     _cachedResultBehavior.add(response);

--- a/lib/src/async.dart
+++ b/lib/src/async.dart
@@ -1,0 +1,185 @@
+import 'dart:async';
+
+import 'package:bloc_helpers/bloc_helpers.dart';
+import 'package:meta/meta.dart';
+import 'package:rxdart/rxdart.dart';
+
+part 'request.dart';
+
+typedef Future<Result> TaskHandler<Parameter, Result>(Parameter parameter);
+
+/// Helper class to implement asynchronous task
+/// Need to implement the [run] method
+abstract class AsyncTaskBloc<Parameter, Result> extends Bloc {
+  final _callPublisher = new PublishSubject<Parameter>();
+
+  // ignore: close_sinks
+  final _resultPublisher = new PublishSubject<Result>();
+
+  // ignore: close_sinks
+  final _runningBehavior = new BehaviorSubject<bool>(seedValue: false);
+
+  AsyncTaskBloc() {
+    onStart.listen(_handleTask);
+  }
+
+  Future<void> _handleTask(Parameter input) async {
+    _runningBehavior.add(true);
+    try {
+      final res = await run(input);
+      _resultPublisher.add(res);
+    } catch (e, s) {
+      _resultPublisher.addError(e, s);
+    } finally {
+      _runningBehavior.add(false);
+    }
+  }
+
+  @mustCallSuper
+  @override
+  FutureOr<void> dispose() async {
+    await _callPublisher.close();
+
+    super.dispose();
+  }
+
+  /// Sink to start the task
+  /// the result and errors are push in the [onResult] stream
+  Sink<Parameter> get callSink => _callPublisher.sink;
+
+  /// Stream representing the current state of the bloc
+  /// true if task is ongoing
+  ValueObservable<bool> get onRunning => _runningBehavior.stream;
+
+  /// Task will start stream
+  Observable<Parameter> get onStart => _callPublisher.stream;
+
+  /// Result stream
+  Observable<Result> get onResult => _resultPublisher.stream;
+
+  /// Create a Task Bloc by passing the function
+  ///
+  /// ```dart
+  /// final taskBloc = new TaskBloc<String,int>.func(myRequest);
+  ///
+  /// Future<int> myRequest(String param) async {
+  ///   ...
+  /// }
+  /// ```
+  factory AsyncTaskBloc.func(TaskHandler<Parameter, Result> handler) =>
+      _AsyncBloc<Parameter, Result>(handler);
+
+  @protected
+  Future<Result> run(Parameter parameter);
+}
+
+class _AsyncBloc<Parameter, Result> extends AsyncTaskBloc<Parameter, Result> {
+  final TaskHandler<Parameter, Result> _request;
+
+  _AsyncBloc(this._request) : super();
+
+  @override
+  Future<Result> run(Parameter parameter) => _request(parameter);
+}
+
+/// Helper class to implement asynchronous task
+/// Need to implement the [run] method
+/// The result is cached to avoid multiple request to a server for exemple
+///
+/// ```dart
+/// cachedTaskBloc.callSink.add('foo'); /// will call [run]
+/// cachedTaskBloc.onResult.first; /// response 'a'
+///
+/// cachedTaskBloc.callSink.add('foo'); /// same input, won't call [run]
+/// cachedTaskBloc.onResult.first; /// response 'a'
+/// ```
+///
+/// If the input change it will invalidate the cache and call [run]
+abstract class AsyncCachedTaskBloc<Parameter, Result>
+    extends AsyncTaskBloc<Parameter, Result> {
+  var _cached = false;
+
+  // ignore: close_sinks
+  final BehaviorSubject<Result> _cachedResultBehavior;
+
+  // ignore: close_sinks
+  final _cachedParameterBehavior = new BehaviorSubject<Parameter>();
+  final _invalidatePublisher = new PublishSubject<Result>();
+
+  /// [seedValue] will init the value of the [cachedResult]
+  AsyncCachedTaskBloc({Result seedValue})
+      : _cachedResultBehavior =
+            new BehaviorSubject<Result>(seedValue: seedValue),
+        super() {
+    onResult.listen(_onResponse, onError: _onError);
+    _invalidatePublisher.stream.listen((value) {
+      _cached = false;
+      _cachedParameterBehavior.add(null);
+
+      if (disposed) return;
+      _cachedResultBehavior.add(value ?? seedValue);
+    });
+  }
+
+  @override
+  Future<void> _handleTask(Parameter input) async {
+    if (_cachedParameterBehavior.value == input && _cached) {
+      _resultPublisher.add(_cachedResultBehavior.value);
+      return;
+    }
+    _cachedParameterBehavior.add(input);
+    super._handleTask(input);
+  }
+
+  void _onError(e, s) {
+    if (disposed) return;
+    _cachedResultBehavior.addError(e, s);
+  }
+
+  void _onResponse(Result response) {
+    _cached = true;
+    if (disposed) return;
+    _cachedResultBehavior.add(response);
+  }
+
+  @override
+  @mustCallSuper
+  FutureOr<void> dispose() async {
+    await _invalidatePublisher.close();
+    await _cachedResultBehavior.close();
+    super.dispose();
+  }
+
+  /// Create a Cached Task Bloc by passing the task function
+  ///
+  /// ```dart
+  /// final requestBloc = new AsyncCachedTaskBloc<String,int>.func(myRequest);
+  ///
+  /// Future<int> myRequest(String input) async {
+  ///   ...
+  /// }
+  /// ```
+  factory AsyncCachedTaskBloc.func(TaskHandler<Parameter, Result> handler) =>
+      new _AsyncCachedTaskBloc<Parameter, Result>(handler);
+
+  /// cached result stream
+  /// Use a Behavior subject so will emit the last value at each `listen`
+  ValueObservable<Result> get cachedResult => _cachedResultBehavior.stream;
+
+  /// Sink to invalidate the cache
+  /// Can take a value if you want to put back the seedValue of the [cachedResult]
+  Sink<Result> get invalidateCacheSink => _invalidatePublisher.sink;
+
+  /// Sink to manualy update the [cachedResult]
+  Sink<Result> get updateCachedResultSink => _cachedResultBehavior.sink;
+}
+
+class _AsyncCachedTaskBloc<Request, Response>
+    extends AsyncCachedTaskBloc<Request, Response> {
+  final TaskHandler<Request, Response> _request;
+
+  _AsyncCachedTaskBloc(this._request) : super();
+
+  @override
+  Future<Response> run(Request input) => _request(input);
+}

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -1,31 +1,24 @@
 part of 'async.dart';
 
-/// Helper class to implement asynchronous call to a server
-/// Need to implement the [request] method
-///
-/// The difference with an AsyncTaskBloc
-/// Is that the taskHandler is using a key to mark the request
-/// if you trigger 2 request at the same time of at a small interval
-/// ```dart
-/// callSink.add(request);
-/// callSink.add(request);
-/// ```
-/// The result of the first one will be ignored
-abstract class RequestBloc<Request, Response>
-    extends AsyncTaskBloc<Request, Response> {
-  RequestBloc();
+mixin _RequestMixin<Request, Response> on AsyncTaskBloc<Request, Response> {
+  var _markerKey = Object();
 
-  /// Create a Request Bloc by passing the request function
-  ///
-  /// ```dart
-  /// final requestBloc = new RequestBloc<String,int>.func(myRequest);
-  ///
-  /// Future<int> myRequest(String input) async {
-  ///   ...
-  /// }
-  /// ```
-  factory RequestBloc.func(TaskHandler<Request, Response> handler) =>
-      new _RequestBloc<Request, Response>(handler);
+  Future<void> _doRequest(Request input) async {
+    _runningBehavior.add(true);
+    try {
+      final key = _markerKey = Object();
+
+      final res = await run(input);
+
+      if (key != _markerKey) return;
+
+      _resultPublisher.add(res);
+    } catch (e, s) {
+      _resultPublisher.addError(e, s);
+    } finally {
+      _runningBehavior.add(false);
+    }
+  }
 
   /// Sink to trigger the request
   /// the response and errors are push in the [onResult] stream
@@ -43,33 +36,45 @@ abstract class RequestBloc<Request, Response>
 
   /// Response stream
   @Deprecated('Use onResult')
-  Observable<Response> get onResult => onResult;
+  Observable<Response> get onResponse => onResult;
+}
+
+/// Helper class to implement asynchronous call to a server
+/// Need to implement the [request] method
+///
+/// The difference with an AsyncTaskBloc
+/// Is that the taskHandler is using a key to mark the request
+/// if you trigger 2 request at the same time of at a small interval
+/// ```dart
+/// callSink.add(request);
+/// callSink.add(request);
+/// ```
+/// The result of the first one will be ignored
+abstract class RequestBloc<Request, Response>
+    extends AsyncTaskBloc<Request, Response>
+    with _RequestMixin<Request, Response> {
+  RequestBloc();
+
+  /// Create a Request Bloc by passing the request function
+  ///
+  /// ```dart
+  /// final requestBloc = new RequestBloc<String,int>.func(myRequest);
+  ///
+  /// Future<int> myRequest(String input) async {
+  ///   ...
+  /// }
+  /// ```
+  factory RequestBloc.func(TaskHandler<Request, Response> handler) =>
+      new _RequestBloc<Request, Response>(handler);
 
   @protected
-  Future<Response> request(Request input);
+  FutureOr<Response> request(Request input);
 
   @protected
-  Future<Response> run(Request input) => request(input);
-
-  var _markerKey = Object();
+  FutureOr<Response> run(Request input) => request(input);
 
   @override
-  Future<void> _handleTask(Request input) async {
-    _runningBehavior.add(true);
-    try {
-      final key = _markerKey = Object();
-
-      final res = await run(input);
-
-      if (key != _markerKey) return;
-
-      _resultPublisher.add(res);
-    } catch (e, s) {
-      _resultPublisher.addError(e, s);
-    } finally {
-      _runningBehavior.add(false);
-    }
-  }
+  Future<void> _handleTask(Request input) => _doRequest(input);
 }
 
 /// Helper class to implement asynchronous call to a server
@@ -86,7 +91,8 @@ abstract class RequestBloc<Request, Response>
 ///
 /// If the request input change it will invalidate the cache and call [request]
 abstract class CachedRequestBloc<Request, Response>
-    extends AsyncCachedTaskBloc<Request, Response> {
+    extends AsyncCachedTaskBloc<Request, Response>
+    with _RequestMixin<Request, Response> {
   /// [seedValue] will init the value of the [cachedResult]
   CachedRequestBloc({Response seedValue}) : super(seedValue: seedValue);
 
@@ -102,24 +108,6 @@ abstract class CachedRequestBloc<Request, Response>
   factory CachedRequestBloc.func(TaskHandler<Request, Response> handler) =>
       new _CachedRequestBloc<Request, Response>(handler);
 
-  /// Sink to trigger the request
-  /// the response and errors are push in the [onResult] stream
-  @Deprecated('Use callSink')
-  Sink<Request> get requestSink => callSink;
-
-  /// Stream representing the current state of the bloc
-  /// true if a request is ongoing
-  @Deprecated('Use onRunning')
-  ValueObservable<bool> get onLoading => onRunning;
-
-  /// Request stream
-  @Deprecated('Use onCall')
-  Observable<Request> get onRequest => onCall;
-
-  /// Response stream
-  @Deprecated('Use onResult')
-  Observable<Response> get onResult => onResult;
-
   /// cached response stream
   /// Use a Behavior subject so will emit the last value at each `listen`
   @Deprecated('Use cachedResult')
@@ -130,10 +118,19 @@ abstract class CachedRequestBloc<Request, Response>
   Sink<Response> get updateCachedResponseSink => updateCachedResultSink;
 
   @protected
-  Future<Response> request(Request input);
+  FutureOr<Response> request(Request input);
 
   @protected
-  Future<Response> run(Request input) => request(input);
+  FutureOr<Response> run(Request input) => request(input);
+
+  @override
+  Future<void> _handleTask(Request input) async {
+    final hitCache = _handleCache(input);
+
+    if (hitCache) return;
+
+    await _doRequest(input);
+  }
 }
 
 class _CachedRequestBloc<Request, Response>
@@ -143,7 +140,7 @@ class _CachedRequestBloc<Request, Response>
   _CachedRequestBloc(this._request) : super();
 
   @override
-  Future<Response> request(Request input) => _request(input);
+  FutureOr<Response> request(Request input) => _request(input);
 }
 
 class _RequestBloc<Request, Response> extends RequestBloc<Request, Response> {
@@ -152,5 +149,5 @@ class _RequestBloc<Request, Response> extends RequestBloc<Request, Response> {
   _RequestBloc(this._request) : super();
 
   @override
-  Future<Response> request(Request input) => _request(input);
+  FutureOr<Response> request(Request input) => _request(input);
 }

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -28,7 +28,7 @@ abstract class RequestBloc<Request, Response>
       new _RequestBloc<Request, Response>(handler);
 
   /// Sink to trigger the request
-  /// the response and errors are push in the [onResponse] stream
+  /// the response and errors are push in the [onResult] stream
   @Deprecated('Use callSink')
   Sink<Request> get requestSink => callSink;
 
@@ -38,12 +38,12 @@ abstract class RequestBloc<Request, Response>
   ValueObservable<bool> get onLoading => onRunning;
 
   /// Request stream
-  @Deprecated('Use onStart')
-  Observable<Request> get onRequest => onStart;
+  @Deprecated('Use onCall')
+  Observable<Request> get onRequest => onCall;
 
   /// Response stream
   @Deprecated('Use onResult')
-  Observable<Response> get onResponse => onResult;
+  Observable<Response> get onResult => onResult;
 
   @protected
   Future<Response> request(Request input);
@@ -78,10 +78,10 @@ abstract class RequestBloc<Request, Response>
 ///
 /// ```dart
 /// cachedRequestBloc.requestSink.add('foo'); /// will call [request]
-/// cachedRequestBloc.onResponse.first; /// response 'a'
+/// cachedRequestBloc.onResult.first; /// response 'a'
 ///
 /// cachedRequestBloc.requestSink.add('foo'); /// same input, won't call [request]
-/// cachedRequestBloc.onResponse.first; /// response 'a'
+/// cachedRequestBloc.onResult.first; /// response 'a'
 /// ```
 ///
 /// If the request input change it will invalidate the cache and call [request]
@@ -103,7 +103,7 @@ abstract class CachedRequestBloc<Request, Response>
       new _CachedRequestBloc<Request, Response>(handler);
 
   /// Sink to trigger the request
-  /// the response and errors are push in the [onResponse] stream
+  /// the response and errors are push in the [onResult] stream
   @Deprecated('Use callSink')
   Sink<Request> get requestSink => callSink;
 
@@ -113,12 +113,12 @@ abstract class CachedRequestBloc<Request, Response>
   ValueObservable<bool> get onLoading => onRunning;
 
   /// Request stream
-  @Deprecated('Use onStart')
-  Observable<Request> get onRequest => onStart;
+  @Deprecated('Use onCall')
+  Observable<Request> get onRequest => onCall;
 
   /// Response stream
   @Deprecated('Use onResult')
-  Observable<Response> get onResponse => onResult;
+  Observable<Response> get onResult => onResult;
 
   /// cached response stream
   /// Use a Behavior subject so will emit the last value at each `listen`

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -1,64 +1,19 @@
-import 'dart:async';
-import 'package:rxdart/rxdart.dart';
-import 'package:meta/meta.dart';
-import 'bloc.dart';
-
-typedef Future<Response> RequestHandler<Request, Response>(Request input);
+part of 'async.dart';
 
 /// Helper class to implement asynchronous call to a server
 /// Need to implement the [request] method
-abstract class RequestBloc<Request, Response> extends Bloc {
-  var _markerKey = new Object();
-
-  final _requestPublisher = new PublishSubject<Request>();
-
-  // ignore: close_sinks
-  final _responsePublisher = new PublishSubject<Response>();
-
-  // ignore: close_sinks
-  final _loadingBehavior = new BehaviorSubject<bool>(seedValue: false);
-
-  RequestBloc() {
-    onRequest.listen(_handleRequest);
-  }
-
-  Future<void> _handleRequest(Request input) async {
-    _loadingBehavior.add(true);
-
-    try {
-      final key = _markerKey = new Object();
-      final res = await request(input);
-
-      if (key != _markerKey) return;
-
-      _responsePublisher.add(res);
-    } catch (e, s) {
-      _responsePublisher.addError(e, s);
-    }
-    _loadingBehavior.add(false);
-  }
-
-  @mustCallSuper
-  @override
-  FutureOr<void> dispose() async {
-    await _requestPublisher.close();
-
-    super.dispose();
-  }
-
-  /// Sink to trigger the request
-  /// the response and errors are push in the [onResponse] stream
-  Sink<Request> get requestSink => _requestPublisher.sink;
-
-  /// Stream representing the current state of the bloc
-  /// true if a request is ongoing
-  ValueObservable<bool> get onLoading => _loadingBehavior.stream;
-
-  /// Request stream
-  Observable<Request> get onRequest => _requestPublisher.stream;
-
-  /// Response stream
-  Observable<Response> get onResponse => _responsePublisher.stream;
+///
+/// The difference with an AsyncTaskBloc
+/// Is that the taskHandler is using a key to mark the request
+/// if you trigger 2 request at the same time of at a small interval
+/// ```dart
+/// callSink.add(request);
+/// callSink.add(request);
+/// ```
+/// The result of the first one will be ignored
+abstract class RequestBloc<Request, Response>
+    extends AsyncTaskBloc<Request, Response> {
+  RequestBloc();
 
   /// Create a Request Bloc by passing the request function
   ///
@@ -69,11 +24,52 @@ abstract class RequestBloc<Request, Response> extends Bloc {
   ///   ...
   /// }
   /// ```
-  factory RequestBloc.func(RequestHandler<Request, Response> handler) =>
+  factory RequestBloc.func(TaskHandler<Request, Response> handler) =>
       new _RequestBloc<Request, Response>(handler);
+
+  /// Sink to trigger the request
+  /// the response and errors are push in the [onResponse] stream
+  @Deprecated('Use callSink')
+  Sink<Request> get requestSink => callSink;
+
+  /// Stream representing the current state of the bloc
+  /// true if a request is ongoing
+  @Deprecated('Use onRunning')
+  ValueObservable<bool> get onLoading => onRunning;
+
+  /// Request stream
+  @Deprecated('Use onStart')
+  Observable<Request> get onRequest => onStart;
+
+  /// Response stream
+  @Deprecated('Use onResult')
+  Observable<Response> get onResponse => onResult;
 
   @protected
   Future<Response> request(Request input);
+
+  @protected
+  Future<Response> run(Request input) => request(input);
+
+  var _markerKey = Object();
+
+  @override
+  Future<void> _handleTask(Request input) async {
+    _runningBehavior.add(true);
+    try {
+      final key = _markerKey = Object();
+
+      final res = await run(input);
+
+      if (key != _markerKey) return;
+
+      _resultPublisher.add(res);
+    } catch (e, s) {
+      _resultPublisher.addError(e, s);
+    } finally {
+      _runningBehavior.add(false);
+    }
+  }
 }
 
 /// Helper class to implement asynchronous call to a server
@@ -90,59 +86,9 @@ abstract class RequestBloc<Request, Response> extends Bloc {
 ///
 /// If the request input change it will invalidate the cache and call [request]
 abstract class CachedRequestBloc<Request, Response>
-    extends RequestBloc<Request, Response> {
-  var _cached = false;
-
-  // ignore: close_sinks
-  final BehaviorSubject<Response> _cachedResponseBehavior;
-
-  // ignore: close_sinks
-  final _cachedRequestBehavior = new BehaviorSubject<Request>();
-  final _invalidatePublisher = new PublishSubject<Response>();
-
-  /// [seedValue] will init the value of the [cachedResponse]
-  CachedRequestBloc({Response seedValue})
-      : _cachedResponseBehavior =
-            new BehaviorSubject<Response>(seedValue: seedValue),
-        super() {
-    onResponse.listen(_onResponse, onError: _onError);
-    _invalidatePublisher.stream.listen((value) {
-      _cached = false;
-      _cachedRequestBehavior.add(null);
-
-      if (disposed) return;
-      _cachedResponseBehavior.add(value ?? seedValue);
-    });
-  }
-
-  @override
-  Future<void> _handleRequest(Request input) async {
-    if (_cachedRequestBehavior.value == input && _cached) {
-      _responsePublisher.add(_cachedResponseBehavior.value);
-      return;
-    }
-    _cachedRequestBehavior.add(input);
-    super._handleRequest(input);
-  }
-
-  void _onError(e, s) {
-    if (disposed) return;
-    _cachedResponseBehavior.addError(e, s);
-  }
-
-  void _onResponse(Response response) {
-    _cached = true;
-    if (disposed) return;
-    _cachedResponseBehavior.add(response);
-  }
-
-  @override
-  @mustCallSuper
-  FutureOr<void> dispose() async {
-    await _invalidatePublisher.close();
-    await _cachedResponseBehavior.close();
-    super.dispose();
-  }
+    extends AsyncCachedTaskBloc<Request, Response> {
+  /// [seedValue] will init the value of the [cachedResult]
+  CachedRequestBloc({Response seedValue}) : super(seedValue: seedValue);
 
   /// Create a Cached Request Bloc by passing the request function
   ///
@@ -153,24 +99,46 @@ abstract class CachedRequestBloc<Request, Response>
   ///   ...
   /// }
   /// ```
-  factory CachedRequestBloc.func(RequestHandler<Request, Response> handler) =>
+  factory CachedRequestBloc.func(TaskHandler<Request, Response> handler) =>
       new _CachedRequestBloc<Request, Response>(handler);
+
+  /// Sink to trigger the request
+  /// the response and errors are push in the [onResponse] stream
+  @Deprecated('Use callSink')
+  Sink<Request> get requestSink => callSink;
+
+  /// Stream representing the current state of the bloc
+  /// true if a request is ongoing
+  @Deprecated('Use onRunning')
+  ValueObservable<bool> get onLoading => onRunning;
+
+  /// Request stream
+  @Deprecated('Use onStart')
+  Observable<Request> get onRequest => onStart;
+
+  /// Response stream
+  @Deprecated('Use onResult')
+  Observable<Response> get onResponse => onResult;
 
   /// cached response stream
   /// Use a Behavior subject so will emit the last value at each `listen`
-  ValueObservable<Response> get cachedResponse => _cachedResponseBehavior.stream;
-
-  /// Sink to invalidate the cache
-  /// Can take a value if you want to put back the seedValue of the cachedResponse
-  Sink<Response> get invalidateCacheSink => _invalidatePublisher.sink;
+  @Deprecated('Use cachedResult')
+  ValueObservable<Response> get cachedResponse => cachedResult;
 
   /// Sink to manualy update the cachedResponse
-  Sink<Response> get updateCachedResponseSink => _cachedResponseBehavior.sink;
+  @Deprecated('Use updateCachedResultSink')
+  Sink<Response> get updateCachedResponseSink => updateCachedResultSink;
+
+  @protected
+  Future<Response> request(Request input);
+
+  @protected
+  Future<Response> run(Request input) => request(input);
 }
 
 class _CachedRequestBloc<Request, Response>
     extends CachedRequestBloc<Request, Response> {
-  final RequestHandler<Request, Response> _request;
+  final TaskHandler<Request, Response> _request;
 
   _CachedRequestBloc(this._request) : super();
 
@@ -179,7 +147,7 @@ class _CachedRequestBloc<Request, Response>
 }
 
 class _RequestBloc<Request, Response> extends RequestBloc<Request, Response> {
-  final RequestHandler<Request, Response> _request;
+  final TaskHandler<Request, Response> _request;
 
   _RequestBloc(this._request) : super();
 

--- a/lib/src/selector.dart
+++ b/lib/src/selector.dart
@@ -96,13 +96,13 @@ class SelectorBloc<T> extends Bloc {
   }
 
   @override
-  FutureOr<void> dispose() async {
+  Future<void> dispose() async {
     await _selectPublisher.close();
     await _unselectPublisher.close();
     await _unselectAllPublisher.close();
     await _selectAllPublisher.close();
     await _clearPublisher.close();
-    super.dispose();
+    await super.dispose();
   }
 
   /// Stream of selected item

--- a/lib/src/selector.dart
+++ b/lib/src/selector.dart
@@ -41,8 +41,15 @@ class SelectorBloc<T> extends Bloc {
   final _unselectAllPublisher = PublishSubject<Iterable<T>>();
   final _clearPublisher = PublishSubject<void>();
 
-  SelectorBloc({this.unique: true, Iterable<T> seedValue})
-      : _selectedBehavior = BehaviorSubject<Iterable<T>>(seedValue: seedValue) {
+  SelectorBloc({List<T> seedValue})
+      : unique = false,
+        _selectedBehavior = BehaviorSubject<List<T>>(seedValue: seedValue) {
+    _initListeners();
+  }
+
+  SelectorBloc.unique({Set<T> seedValue})
+      : unique = true,
+        _selectedBehavior = BehaviorSubject<Set<T>>(seedValue: seedValue) {
     _initListeners();
   }
 
@@ -95,7 +102,6 @@ class SelectorBloc<T> extends Bloc {
     await _unselectAllPublisher.close();
     await _selectAllPublisher.close();
     await _clearPublisher.close();
-
     super.dispose();
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: bloc_helpers
 description: Set of helpers class and function to implements Bloc pattern
 homepage: https://github.com/lejard-h/bloc_helpers
 author: Hadrien Lejard <hadrien.lejard@gmail.com>
-version: 0.1.1
+version: 0.2.0
 
 environment:
   sdk: '>=1.23.0 <3.0.0'
@@ -10,3 +10,4 @@ environment:
 dependencies:
   rxdart: '>=0.17.0 <1.0.0'
   meta: ^1.1.0
+  test: ^1.5.0

--- a/test/async_test.dart
+++ b/test/async_test.dart
@@ -14,7 +14,7 @@ class CachedMockRequest extends CachedRequestBloc<String, int> {
   }
 
   @override
-  FutureOr<void> dispose() {
+  Future<void> dispose() {
     hitRequest.close();
     return super.dispose();
   }

--- a/test/async_test.dart
+++ b/test/async_test.dart
@@ -1,0 +1,189 @@
+import 'dart:async';
+
+import 'package:bloc_helpers/bloc_helpers.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:test/test.dart';
+
+class CachedMockRequest extends CachedRequestBloc<String, int> {
+  final hitRequest = PublishSubject<void>();
+
+  @override
+  Future<int> request(String input) async {
+    hitRequest.add(null);
+    return int.parse(input);
+  }
+
+  @override
+  FutureOr<void> dispose() {
+    hitRequest.close();
+    return super.dispose();
+  }
+}
+
+void main() {
+  group('request bloc', () {
+    RequestBloc<String, int> _initBloc() => RequestBloc<String, int>.func(
+          (req) async => int.parse(req),
+        );
+
+    test('response', () async {
+      final bloc = _initBloc();
+
+      scheduleMicrotask(() {
+        bloc.callSink.add('10');
+        bloc.callSink.add('5');
+        bloc.dispose();
+      });
+
+      await expectLater(
+          bloc.onResult,
+          emitsInOrder(<dynamic>[
+            10,
+            5,
+          ]));
+    });
+
+    test('1 response for same request', () async {
+      final bloc = _initBloc();
+
+      scheduleMicrotask(() {
+        bloc.callSink.add('10');
+        bloc.callSink.add('10');
+        bloc.dispose();
+      });
+
+      await expectLater(
+          bloc.onResult,
+          emitsInOrder(<dynamic>[
+            10,
+          ]));
+    });
+
+    test('loading', () async {
+      final bloc = _initBloc();
+
+      scheduleMicrotask(() {
+        bloc.callSink.add('10');
+        bloc.dispose();
+      });
+
+      await expectLater(
+          bloc.onRunning,
+          emitsInOrder(<dynamic>[
+            false,
+            true,
+            false,
+          ]));
+    });
+
+    test('loading on error', () async {
+      final bloc = _initBloc();
+
+      scheduleMicrotask(() {
+        bloc.callSink.add('aaa');
+        bloc.dispose();
+      });
+
+      await expectLater(
+          bloc.onRunning,
+          emitsInOrder(<dynamic>[
+            false,
+            true,
+            false,
+          ]));
+    });
+
+    test('fire error', () async {
+      final bloc = _initBloc();
+
+      scheduleMicrotask(() {
+        bloc.callSink.add('aaa');
+        bloc.dispose();
+      });
+
+      await expectLater(
+        bloc.onResult,
+        emitsError(TypeMatcher<FormatException>()),
+      );
+    });
+  });
+
+  group('cached request bloc', () {
+    CachedMockRequest _initBloc() => CachedMockRequest();
+
+    test('update cached response', () async {
+      final bloc = _initBloc();
+
+      scheduleMicrotask(() async {
+        bloc.callSink.add('10');
+
+        await Future.delayed(const Duration(milliseconds: 500));
+
+        bloc.callSink.add('10');
+        bloc.dispose();
+      });
+
+      await expectLater(
+          bloc.cachedResult,
+          emitsInOrder(
+            <dynamic>[10],
+          ));
+    });
+
+    test('no loading if hit cache', () async {
+      final bloc = _initBloc();
+
+      scheduleMicrotask(() async {
+        bloc.callSink.add('10');
+
+        await Future.delayed(const Duration(milliseconds: 500));
+
+        bloc.callSink.add('10');
+        bloc.dispose();
+      });
+
+      await expectLater(
+          bloc.onRunning,
+          emitsInOrder(<dynamic>[
+            false,
+            true,
+            false,
+          ]));
+    });
+
+    test('1 response for 1 request', () async {
+      final bloc = _initBloc();
+
+      scheduleMicrotask(() async {
+        bloc.callSink.add('10');
+
+        await Future.delayed(const Duration(milliseconds: 500));
+
+        bloc.callSink.add('10');
+        bloc.dispose();
+      });
+
+      await expectLater(
+          bloc.onResult,
+          emitsInOrder(<dynamic>[
+            10,
+            10,
+          ]));
+    });
+
+    test('hit cache if same request', () async {
+      final bloc = _initBloc();
+
+      scheduleMicrotask(() async {
+        bloc.callSink.add('10');
+
+        await Future.delayed(const Duration(milliseconds: 500));
+
+        bloc.callSink.add('10');
+        bloc.dispose();
+      });
+
+      await expectLater(bloc.hitRequest, emitsInOrder(<dynamic>[null]));
+    });
+  });
+}

--- a/test/selector_test.dart
+++ b/test/selector_test.dart
@@ -1,0 +1,207 @@
+import 'dart:async';
+
+import 'package:test/test.dart';
+import 'package:bloc_helpers/bloc_helpers.dart';
+
+void main() {
+  group('selector bloc not unique', () {
+    SelectorBloc _initBloc() => SelectorBloc<String>(
+          seedValue: ['foo', 'foo', 'bar'],
+        );
+
+    test('seed', () async {
+      final bloc = _initBloc();
+
+      await expectLater(bloc.selected, emits(['foo', 'foo', 'bar']));
+
+      bloc.dispose();
+    });
+
+    test('select', () async {
+      final bloc = SelectorBloc<String>();
+
+      scheduleMicrotask(() {
+        bloc.selectSink.add('foo');
+        bloc.selectSink.add('foo');
+        bloc.selectSink.add('bar');
+        bloc.dispose();
+      });
+
+      await expectLater(
+          bloc.selected,
+          emitsInOrder(<dynamic>[
+            ['foo'],
+            ['foo', 'foo'],
+            ['foo', 'foo', 'bar'],
+          ]));
+    });
+    test('unselect', () async {
+      final bloc = _initBloc();
+
+      scheduleMicrotask(() {
+        bloc.unselectSink.add('bar');
+        bloc.dispose();
+      });
+
+      await expectLater(
+          bloc.selected,
+          emitsInOrder(<dynamic>[
+            ['foo', 'foo', 'bar'],
+            ['foo', 'foo']
+          ]));
+    });
+    test('selectAll', () async {
+      final bloc = _initBloc();
+
+      scheduleMicrotask(() {
+        bloc.selectAllSink.add(<String>['42', '1337']);
+        bloc.dispose();
+      });
+
+      await expectLater(
+          bloc.selected,
+          emitsInOrder(<dynamic>[
+            ['foo', 'foo', 'bar'],
+            [
+              'foo',
+              'foo',
+              'bar',
+              '42',
+              '1337',
+            ]
+          ]));
+    });
+    test('unselectAll', () async {
+      final bloc = _initBloc();
+
+      scheduleMicrotask(() {
+        bloc.unselectAllSink.add(<String>['foo', 'bar']);
+        bloc.dispose();
+      });
+
+      await expectLater(
+        bloc.selected,
+        emitsInOrder(<dynamic>[
+          ['foo', 'foo', 'bar'],
+          []
+        ]),
+      );
+    });
+    test('clear', () async {
+      final bloc = _initBloc();
+
+      scheduleMicrotask(() {
+        bloc.clearSink.add(null);
+        bloc.dispose();
+      });
+
+      await expectLater(
+        bloc.selected,
+        emitsInOrder(<dynamic>[
+          ['foo', 'foo', 'bar'],
+          []
+        ]),
+      );
+    });
+  });
+
+  group('selector bloc unique', () {
+    SelectorBloc _initBloc() => SelectorBloc<String>.unique(
+          seedValue: Set.from(['foo', 'foo', 'bar']),
+        );
+
+    test('seed', () async {
+      final bloc = _initBloc();
+
+      await expectLater(bloc.selected, emits(['foo', 'bar']));
+
+      bloc.dispose();
+    });
+
+    test('select', () async {
+      final bloc = SelectorBloc<String>.unique();
+
+      scheduleMicrotask(() {
+        bloc.selectSink.add('foo');
+        bloc.selectSink.add('foo');
+        bloc.selectSink.add('bar');
+        bloc.dispose();
+      });
+
+      await expectLater(
+          bloc.selected,
+          emitsInOrder(<dynamic>[
+            ['foo'],
+            ['foo'],
+            ['foo','bar'],
+          ]));
+    });
+    test('unselect', () async {
+      final bloc = _initBloc();
+
+      scheduleMicrotask(() {
+        bloc.unselectSink.add('bar');
+        bloc.dispose();
+      });
+
+      await expectLater(
+          bloc.selected,
+          emitsInOrder(<dynamic>[
+            ['foo','bar'],
+            ['foo']
+          ]));
+    });
+    test('selectAll', () async {
+      final bloc = _initBloc();
+
+      scheduleMicrotask(() {
+        bloc.selectAllSink.add(<String>['42', '42', '1337']);
+        bloc.dispose();
+      });
+
+      await expectLater(
+          bloc.selected,
+          emitsInOrder(<dynamic>[
+            ['foo',  'bar'],
+            [
+              'foo',
+              'bar',
+              '42',
+              '1337',
+            ]
+          ]));
+    });
+    test('unselectAll', () async {
+      final bloc = _initBloc();
+
+      scheduleMicrotask(() {
+        bloc.unselectAllSink.add(<String>['foo', 'bar']);
+        bloc.dispose();
+      });
+
+      await expectLater(
+        bloc.selected,
+        emitsInOrder(<dynamic>[
+          ['foo', 'bar'],
+          []
+        ]),
+      );
+    });
+    test('clear', () async {
+      final bloc = _initBloc();
+
+      scheduleMicrotask(() {
+        bloc.clearSink.add(null);
+        bloc.dispose();
+      });
+
+      await expectLater(
+        bloc.selected,
+        emitsInOrder(<dynamic>[
+          ['foo', 'bar'],
+          []
+        ]),
+      );
+    });
+  });
+}


### PR DESCRIPTION
- ***Breaking Change***
    use contructor for unique selector
        SelectorBloc(); // not unique
        SelectorBloc.unique();

- `AsyncTaskBloc` and `AsyncCachedTaskBloc`

- ***Deprecated***
    + `requestSink` renamed to `callSink`
    + `onLoading` renamed to `onRunning`
    + `onRequest` renamed to `onResult`
    + `onRequest` renamed to `onCall`
    + `cachedResponse` renamed to `cachedResult`
    + `updateCachedResponseSink` to `updateCachedResultSink`